### PR TITLE
Supports custom Onion URLs on CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+sdstatus

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.DEFAULT_GOAL := help
+
+.PHONY: build
+build: ## Compiles Golang binary
+	go build
+
+.PHONY: test
+test: build ## Queries a random Onion URL from the hardcoded list
+	sort --random-sort sdonion.txt \
+		| head -n 1 \
+		| xargs ./sdstatus
+
+.PHONY: help
+help: ## Prints this message and exits.
+	@printf "Makefile for developing and testing FPF infrastructure.\n"
+	@printf "Subcommands:\n\n"
+	@perl -F':.*##\s+' -lanE '$$F[1] and say "\033[36m$$F[0]\033[0m : $$F[1]"' $(MAKEFILE_LIST) \
+		| sort \
+		| column -s ':' -t

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ build: ## Compiles Golang binary
 	go build
 
 .PHONY: test
-test: build ## Queries a random Onion URL from the hardcoded list
+test: ## Queries a random Onion URL from the hardcoded list
 	sort --random-sort sdonion.txt \
 		| head -n 1 \
-		| xargs ./sdstatus
+		| xargs go run main.go
 
 .PHONY: help
 help: ## Prints this message and exits.

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -168,6 +169,9 @@ func createApp() *cli.App {
 		csv := c.GlobalBool("csv")
 		all := c.GlobalBool("all")
 		onion_urls := c.Args()
+		if !all && len(onion_urls) == 0 {
+			log.Fatal("No args provided. Pass --all to use hardcoded list")
+		}
 		runScan(csv, all, onion_urls)
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func checkStatus(ch chan Information, client *http.Client, url string) {
 	ch <- result
 }
 
-func runScan(csv bool) {
+func runScan(csv bool, all bool) {
 	i := 0
 
 	results := make([]SDInfo, 0)
@@ -155,13 +155,16 @@ func createApp() *cli.App {
 			Usage: "Prints output in CSV format",
 		},
 	}
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "all",
+			Usage: "Scans all known instances, via hardcoded list",
+		},
+	}
 	app.Action = func(c *cli.Context) error {
 		csv := c.GlobalBool("csv")
-		if csv {
-			runScan(csv)
-		} else {
-			runScan(false)
-		}
+		all := c.GlobalBool("all")
+		runScan(csv, all)
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func checkStatus(ch chan Information, client *http.Client, url string) {
 	ch <- result
 }
 
-func runScan(csv bool, all bool) {
+func runScan(csv bool, all bool, onion_urls []string) {
 	i := 0
 
 	results := make([]SDInfo, 0)
@@ -101,13 +101,16 @@ func runScan(csv bool, all bool) {
 
 	ch := make(chan Information)
 
-	// Now let us find the onion addresses
-	data, err := ioutil.ReadFile("sdonion.txt")
-	check(err)
-	lines := strings.Split(string(data), "\n")
+	// Prefer args passed on CLI, fall back to hardcoded list
+	if len(onion_urls) == 0 {
+		// Now let us find the onion addresses
+		data, err := ioutil.ReadFile("sdonion.txt")
+		check(err)
+		onion_urls = strings.Split(string(data), "\n")
+	}
 
 	// For each address we are creating a goroutine
-	for _, v := range lines {
+	for _, v := range onion_urls {
 		url := strings.TrimSpace(v)
 
 		if url != "" {
@@ -164,7 +167,8 @@ func createApp() *cli.App {
 	app.Action = func(c *cli.Context) error {
 		csv := c.GlobalBool("csv")
 		all := c.GlobalBool("all")
-		runScan(csv, all)
+		onion_urls := c.Args()
+		runScan(csv, all, onion_urls)
 		return nil
 	}
 


### PR DESCRIPTION
Closes #1.

Custom Onion URLs for SD instances can now be passed via CLI, regardless of whether those URLs are already specified inside the hardcoded list inside the repo. Sprinkled in a few dev-env-related files like gitignore and a small Makefile. 

Note there's a breaking API change here, in that `--all` must be passed in order to use the hardcoded list; otherwise the script now fails:

```
$ ./sdstatus 
2018/05/13 18:03:31 No args provided. Pass --all to use hardcoded list
```

You can also use `make test` to query a random URL from the hardcoded list, and pass that into the script. Hardly a "test", truly, but does provide useful feedback during development. 