### PR TITLE
Add a `rust-toolchain.toml` file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.58.1"


### PR DESCRIPTION
This pins the version of Rust used.